### PR TITLE
yaml update for latest cobaya devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+dist: bionic
+
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install gfortran
+  - gfortran --version
+  - python --version
+  - pip install camb==1.0.12
+
+install:
+  - pip install .
+
+script:
+  - python -m unittest mflike.tests.test_mflike

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,12 @@
 LAT Multifrequency Likelihood
 =============================
 
+.. image:: https://travis-ci.com/simonsobs/LAT_MFLike.svg?branch=master
+   :target: https://travis-ci.com/simonsobs/LAT_MFLike
+
+.. image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/simonsobs/LAT_MFLike/binder?filepath=notebooks%2Fmflike_tutorial.ipynb
+
 
 External likelihood using `cobaya <https://github.com/CobayaSampler/cobaya>`_.
 
@@ -56,8 +62,3 @@ You can test the ``mflike`` likelihood by doing
 which should run a MCMC sampler for the first simulation (*i.e.* ``sim_id: 0`` in the
 ``test_mflike.yaml`` file) using the combination of TT, TE and EE spectra (*i.e.* ``select:
 tt-te-ee``). The results will be stored in the ``chains/mcmc`` directory.
-
-You can also have a look into the interactive tutorial
-
-.. image:: https://mybinder.org/badge_logo.svg
- :target: https://mybinder.org/v2/gh/simonsobs/LAT_MFLike/binder?filepath=notebooks%2Fmflike_tutorial.ipynb

--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,14 @@
 LAT Multifrequency Likelihood
 =============================
 
+An external likelihood using `cobaya <https://github.com/CobayaSampler/cobaya>`_.
+
 .. image:: https://travis-ci.com/simonsobs/LAT_MFLike.svg?branch=master
    :target: https://travis-ci.com/simonsobs/LAT_MFLike
 
 .. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/simonsobs/LAT_MFLike/binder?filepath=notebooks%2Fmflike_tutorial.ipynb
 
-
-External likelihood using `cobaya <https://github.com/CobayaSampler/cobaya>`_.
 
 Installing the code
 -------------------

--- a/mflike/MFLike.yaml
+++ b/mflike/MFLike.yaml
@@ -1,36 +1,35 @@
 # A simple cobaya likelihood for SO/LAT
-likelihood:
-  __self__:
-    path: null
-    data_folder: LAT_MFLike_data/like_products
 
-    sim_id: null
+path: null
+data_folder: LAT_MFLike_data/like_products
 
-    select: tt-te-ee
+sim_id: null
 
-    experiments:
-      - LAT:
-        - 93  # GHz
-        - 145 # GHz
-        - 225 # GHz
+select: tt-te-ee
 
-    foregrounds:
-      normalisation:
-        nu_0: 150.0
-        ell_0: 3000
-        T_CMB: 2.725
+experiments:
+  - LAT:
+    - 93  # GHz
+    - 145 # GHz
+    - 225 # GHz
 
-      components:
-        tt:
-          - kSZ
-          - cibp
-          - radio
-          - tSZ
-          - cibc
-        te: []
-        ee: []
+foregrounds:
+  normalisation:
+    nu_0: 150.0
+    ell_0: 3000
+    T_CMB: 2.725
 
-    lmax: 6002
+  components:
+    tt:
+      - kSZ
+      - cibp
+      - radio
+      - tSZ
+      - cibc
+    te: []
+    ee: []
+
+lmax: 6002
 
 params:
   # Foregrounds

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -15,6 +15,7 @@ from cobaya.tools import are_different_params_lists
 from cobaya.conventions import _path_install
 from cobaya.likelihoods._base_classes import _InstallableLikelihood
 
+
 class MFLike(_InstallableLikelihood):
     install_options = {"github_repository": "simonsobs/LAT_MFLike_data",
                        "github_release": "v0.1"}
@@ -33,21 +34,22 @@ class MFLike(_InstallableLikelihood):
         if not os.path.exists(self.data_folder):
             raise LoggedError(
                 self.log, "The 'data_folder' directory does not exist. "
-                "Check the given path [%s].", self.data_folder)
+                          "Check the given path [%s].", self.data_folder)
 
         # State requisites to the theory code
         self.requested_cls = ["tt", "te", "ee"]
 
         self.expected_params = ["a_tSZ", "a_kSZ", "a_p", "beta_p",
                                 "a_c", "beta_c", "n_CIBC", "a_s", "T_d"]
-        if hasattr(self, "input_params"):
-            # Check that the parameters are the right ones
-            differences = are_different_params_lists(
-                self.input_params, self.expected_params, name_A="given", name_B="expected")
-            if differences:
-                raise LoggedError(
-                    self.log, "Configuration error in parameters: %r.", differences)
         self._prepare_data()
+
+    def initialize_with_params(self):
+        # Check that the parameters are the right ones
+        differences = are_different_params_lists(
+            self.input_params, self.expected_params, name_A="given", name_B="expected")
+        if differences:
+            raise LoggedError(
+                self.log, "Configuration error in parameters: %r.", differences)
 
     def get_requirements(self):
         # Same lmax for different cls
@@ -117,7 +119,7 @@ class MFLike(_InstallableLikelihood):
                 if self.select == s:
                     n_bins = int(cov_mat.shape[0])
                     cov_mat = cov_mat[count * n_bins // 3:(count + 1) * n_bins // 3,
-                                      count * n_bins // 3:(count + 1) * n_bins // 3]
+                              count * n_bins // 3:(count + 1) * n_bins // 3]
         # Store inverted covariance matrix
         self.inv_cov = np.linalg.inv(cov_mat)
 

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -38,6 +38,8 @@ class MFLike(_InstallableLikelihood):
 
         # State requisites to the theory code
         self.requested_cls = ["tt", "te", "ee"]
+        # Same lmax for different cls
+        self.l_maxs_cls = [self.lmax for i in self.requested_cls]
 
         self.expected_params = ["a_tSZ", "a_kSZ", "a_p", "beta_p",
                                 "a_c", "beta_c", "n_CIBC", "a_s", "T_d"]
@@ -52,8 +54,6 @@ class MFLike(_InstallableLikelihood):
                 self.log, "Configuration error in parameters: %r.", differences)
 
     def get_requirements(self):
-        # Same lmax for different cls
-        self.l_maxs_cls = [self.lmax for i in self.requested_cls]
         return dict(Cl=dict(zip(self.requested_cls, self.l_maxs_cls)))
 
     def logp(self, **params_values):

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -1,0 +1,67 @@
+import unittest
+import os
+
+modules_path = os.environ.get("COBAYA_MODULES_PATH") or "/tmp/modules"
+
+cosmo_params = {
+    "cosmomc_theta": 0.0104085,
+    "As": 2.0989031673191437e-09,
+    "ombh2": 0.02237,
+    "omch2": 0.1200,
+    "ns": 0.9649,
+    "Alens": 1.0,
+    "tau": 0.0544
+}
+
+nuisance_params= {
+    "a_tSZ": 3.30,
+    "a_kSZ": 1.60,
+    "a_p": 6.90,
+    "beta_p": 2.08,
+    "a_c": 4.90,
+    "beta_c": 2.20,
+    "n_CIBC": 1.20,
+    "a_s": 3.10,
+    "T_d": 9.60
+}
+
+chi2s = {
+    "tt": 482.3467119,
+    "te": 487.6017977,
+    "ee": 542.8604275,
+    "tt-te-ee": 1536.6415237}
+
+class MFLikeTest(unittest.TestCase):
+    def setUp(self):
+        from cobaya.install import install
+        install({"likelihood": {"mflike.MFLike": None}}, path=modules_path)
+
+    def test_mflike(self):
+        from mflike import MFLike
+        my_mflike = MFLike({"path_install": modules_path, "sim_id": 0})
+        import camb
+        camb_cosmo = cosmo_params.copy()
+        camb_cosmo.update({"lmax": my_mflike.lmax, "lens_potential_accuracy": 1})
+        pars = camb.set_params(**camb_cosmo)
+        results = camb.get_results(pars)
+        powers = results.get_cmb_power_spectra(pars, CMB_unit="muK")
+        cl_dict = {k: powers["total"][:, v]
+                   for k, v in {"tt": 0, "ee": 1, "te": 3}.items()}
+        loglike = my_mflike.loglike(cl_dict, **nuisance_params)
+        self.assertAlmostEqual(-2 * loglike, chi2s["tt-te-ee"], 7)
+
+        for select, chi2 in chi2s.items():
+            my_mflike = MFLike({"path_install": modules_path,
+                                "sim_id": 0, "select": select})
+            loglike = my_mflike.loglike(cl_dict, **nuisance_params)
+            self.assertAlmostEqual(-2 * loglike, chi2, 7)
+
+    def test_cobaya(self):
+        info = {"likelihood": {"mflike.MFLike": {"sim_id": 0}},
+                "theory": {"camb": {"extra_args": {"lens_potential_accuracy": 1}}},
+                "params": cosmo_params,
+                "modules": modules_path}
+        from cobaya.model import get_model
+        model = get_model(info)
+        chi2 = -2 * model.loglikes(nuisance_params)[0]
+        self.assertAlmostEqual(chi2[0], chi2s["tt-te-ee"], 7)

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -26,10 +26,10 @@ nuisance_params= {
 }
 
 chi2s = {
-    "tt": 482.3467119,
-    "te": 487.6017977,
-    "ee": 542.8604275,
-    "tt-te-ee": 1536.6415237}
+    "tt": 482.3467,
+    "te": 487.6017,
+    "ee": 542.8604,
+    "tt-te-ee": 1536.6415}
 
 class MFLikeTest(unittest.TestCase):
     def setUp(self):
@@ -47,14 +47,11 @@ class MFLikeTest(unittest.TestCase):
         powers = results.get_cmb_power_spectra(pars, CMB_unit="muK")
         cl_dict = {k: powers["total"][:, v]
                    for k, v in {"tt": 0, "ee": 1, "te": 3}.items()}
-        loglike = my_mflike.loglike(cl_dict, **nuisance_params)
-        self.assertAlmostEqual(-2 * loglike, chi2s["tt-te-ee"], 7)
-
         for select, chi2 in chi2s.items():
             my_mflike = MFLike({"path_install": modules_path,
                                 "sim_id": 0, "select": select})
             loglike = my_mflike.loglike(cl_dict, **nuisance_params)
-            self.assertAlmostEqual(-2 * loglike, chi2, 7)
+            self.assertAlmostEqual(-2 * loglike, chi2, 3)
 
     def test_cobaya(self):
         info = {"likelihood": {"mflike.MFLike": {"sim_id": 0}},
@@ -64,4 +61,4 @@ class MFLikeTest(unittest.TestCase):
         from cobaya.model import get_model
         model = get_model(info)
         chi2 = -2 * model.loglikes(nuisance_params)[0]
-        self.assertAlmostEqual(chi2[0], chi2s["tt-te-ee"], 7)
+        self.assertAlmostEqual(chi2[0], chi2s["tt-te-ee"], 3)


### PR DESCRIPTION
The cobaya devel branch now has two big commits to support multiple theories and some refactorings. The .yaml defaults no longer have `likelihood: __self__` in them.

I haven't tested it with this repo, but works with my test external likelihoods. Would be nice if we could add a simple test module so this module can be tested easily; just something very simple like
https://github.com/CobayaSampler/planck_lensing_external/blob/master/plancklens/tests/test_likes.py
would be fine. I can also help you set it up on travis if you like.