### PR TITLE
Add normalizing constant to logp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get -y install gfortran
   - gfortran --version
   - python --version
-  - pip install camb==1.0.12
+  - pip install camb
 
 install:
   - pip install .

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -63,7 +63,7 @@ class MFLike(_InstallableLikelihood):
     def loglike(self, cl, **params_values):
         ps_vec = self._get_power_spectra(cl, **params_values)
         delta = self.data_vec - ps_vec
-        logp = -0.5 * np.dot(delta, self.inv_cov.dot(delta))
+        logp = -0.5 * np.dot(delta, self.inv_cov.dot(delta)) + self.logp_const
         self.log.debug(
             "Log-likelihood value computed = {} (Χ² = {})".format(logp, -2 * logp))
         return logp
@@ -122,6 +122,9 @@ class MFLike(_InstallableLikelihood):
                               count * n_bins // 3:(count + 1) * n_bins // 3]
         # Store inverted covariance matrix
         self.inv_cov = np.linalg.inv(cov_mat)
+        self.logp_const = np.log(2 * np.pi) * (-len(self.data_vec) / 2) + np.linalg.slogdet(cov_mat)[1] * (
+            -1 / 2
+        )
 
     def _read_spectra(self, fname):
         data = np.loadtxt(fname)

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -51,7 +51,7 @@ class MFLikeTest(unittest.TestCase):
             my_mflike = MFLike({"path_install": modules_path,
                                 "sim_id": 0, "select": select})
             loglike = my_mflike.loglike(cl_dict, **nuisance_params)
-            self.assertAlmostEqual(-2 * loglike, chi2, 3)
+            self.assertAlmostEqual(-2 * (loglike - my_mflike.logp_const), chi2, 3)
 
     def test_cobaya(self):
         info = {"likelihood": {"mflike.MFLike": {"sim_id": 0}},
@@ -60,5 +60,6 @@ class MFLikeTest(unittest.TestCase):
                 "modules": modules_path}
         from cobaya.model import get_model
         model = get_model(info)
-        chi2 = -2 * model.loglikes(nuisance_params)[0]
+        my_mflike = model.likelihood["mflike.MFLike"]
+        chi2 = -2 * (model.loglikes(nuisance_params)[0] - my_mflike.logp_const)
         self.assertAlmostEqual(chi2[0], chi2s["tt-te-ee"], 3)


### PR DESCRIPTION
This adds the normalizing constant to the multivariate normal logpdf calculation, to allow for testing an alternate implementation of this same likelihood that computes the normalized logp.