### PR TITLE
Feature new sim release

### DIFF
--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -18,7 +18,7 @@ from cobaya.likelihoods._base_classes import _InstallableLikelihood
 
 class MFLike(_InstallableLikelihood):
     install_options = {"github_repository": "simonsobs/LAT_MFLike_data",
-                       "github_release": "v0.1"}
+                       "github_release": "v0.2"}
 
     def initialize(self):
         self.log.info("Initialising.")
@@ -54,7 +54,7 @@ class MFLike(_InstallableLikelihood):
                 self.log, "Configuration error in parameters: %r.", differences)
 
     def get_requirements(self):
-        return dict(Cl=dict(zip(self.requested_cls, self.l_maxs_cls)))
+        return dict(Cl=dict(zip(self.requested_cls, np.maximum(self.l_maxs_cls, 9000))))
 
     def logp(self, **params_values):
         cl = self.theory.get_Cl(ell_factor=True)

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -37,8 +37,6 @@ class MFLikeTest(unittest.TestCase):
         install({"likelihood": {"mflike.MFLike": None}}, path=modules_path)
 
     def test_mflike(self):
-        from mflike import MFLike
-        my_mflike = MFLike({"path_install": modules_path, "sim_id": 0})
         import camb
         camb_cosmo = cosmo_params.copy()
         camb_cosmo.update({"lmax": 9000, "lens_potential_accuracy": 1})
@@ -48,10 +46,11 @@ class MFLikeTest(unittest.TestCase):
         cl_dict = {k: powers["total"][:, v]
                    for k, v in {"tt": 0, "ee": 1, "te": 3}.items()}
         for select, chi2 in chi2s.items():
+            from mflike import MFLike
             my_mflike = MFLike({"path_install": modules_path,
                                 "sim_id": 0, "select": select})
             loglike = my_mflike.loglike(cl_dict, **nuisance_params)
-            self.assertAlmostEqual(-2 * (loglike - my_mflike.logp_const), chi2, 3)
+            self.assertAlmostEqual(-2 * (loglike - my_mflike.logp_const), chi2, 2)
 
     def test_cobaya(self):
         info = {"likelihood": {"mflike.MFLike": {"sim_id": 0}},
@@ -62,4 +61,4 @@ class MFLikeTest(unittest.TestCase):
         model = get_model(info)
         my_mflike = model.likelihood["mflike.MFLike"]
         chi2 = -2 * (model.loglikes(nuisance_params)[0] - my_mflike.logp_const)
-        self.assertAlmostEqual(chi2[0], chi2s["tt-te-ee"], 3)
+        self.assertAlmostEqual(chi2[0], chi2s["tt-te-ee"], 2)

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -26,10 +26,10 @@ nuisance_params= {
 }
 
 chi2s = {
-    "tt": 482.3467,
-    "te": 487.6017,
-    "ee": 542.8604,
-    "tt-te-ee": 1536.6415}
+    "tt": 490.4163,
+    "te": 482.3090,
+    "ee": 511.1752,
+    "tt-te-ee": 1488.9766}
 
 class MFLikeTest(unittest.TestCase):
     def setUp(self):
@@ -41,7 +41,7 @@ class MFLikeTest(unittest.TestCase):
         my_mflike = MFLike({"path_install": modules_path, "sim_id": 0})
         import camb
         camb_cosmo = cosmo_params.copy()
-        camb_cosmo.update({"lmax": my_mflike.lmax, "lens_potential_accuracy": 1})
+        camb_cosmo.update({"lmax": 9000, "lens_potential_accuracy": 1})
         pars = camb.set_params(**camb_cosmo)
         results = camb.get_results(pars)
         powers = results.get_cmb_power_spectra(pars, CMB_unit="muK")


### PR DESCRIPTION
- Use `v0.2` release of `LAT_MFLike_data`
- Fix `lmax` value to use the same as in simulation
- Reduce decimal tolerance for unit test 