### PR TITLE
New data release (v0.6)

### DIFF
--- a/mflike/MFLike.yaml
+++ b/mflike/MFLike.yaml
@@ -1,6 +1,6 @@
 # A simple cobaya likelihood for SO/LAT
 
-data_folder: MFLike/v0.5
+data_folder: MFLike/v0.6
 # Path to the input SACC file, containing, minimally,
 # information about the different tracers (i.e. frequency
 # bands) and the set of power spectra.
@@ -19,10 +19,10 @@ defaults:
   polarizations: ['TT', 'TE', 'ET', 'EE']
   # Scale cuts (in ell) for each spectrum
   scales:
-    TT: [2, 6002]
-    TE: [2, 6002]
-    ET: [2, 6002]
-    EE: [2, 6002]
+    TT: [2, 5000]
+    TE: [2, 5000]
+    ET: [2, 5000]
+    EE: [2, 5000]
   # If True, TE' = (TE + ET) / 2 will be used
   # instead of TE and ET separately.
   symmetrize: False

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -18,7 +18,7 @@ from cobaya.tools import are_different_params_lists
 
 class MFLike(_InstallableLikelihood):
     _url = "https://portal.nersc.gov/cfs/sobs/users/MFLike_data"
-    _release = "v0.5"
+    _release = "v0.6"
     install_options = {"download_url": "{}/{}.tar.gz".format(_url, _release)}
 
     # attributes set from .yaml

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -28,7 +28,7 @@ nuisance_params = {
     "T_d": 9.60,
 }
 
-chi2s = {"tt": 1421.0148, "te": 1409.3179, "ee": 1342.9600, "tt-te-et-ee": 2525.2791}
+chi2s = {"tt": 1384.5669, "te": 1400.2760, "ee": 1428.7597, "tt-te-et-ee": 2412.9275}
 pre = "data_sacc_"
 
 
@@ -58,10 +58,10 @@ class MFLikeTest(unittest.TestCase):
                     "defaults": {
                         "polarizations": select.upper().split("-"),
                         "scales": {
-                            "TT": [2, 6002],
-                            "TE": [2, 6002],
-                            "ET": [2, 6002],
-                            "EE": [2, 6002],
+                            "TT": [2, 5000],
+                            "TE": [2, 5000],
+                            "ET": [2, 5000],
+                            "EE": [2, 5000],
                         },
                         "symmetrize": False,
                     },


### PR DESCRIPTION
CMB simulation are MBS ones https://github.com/simonsobs/map_based_simulations/tree/master/201911_lensed_cmb with the associated CAMB `ini` file https://mapsims.readthedocs.io/en/latest/camb.html

Foregrounds simulations are `fgspectra` ones with the following parameters:

```yaml
a_tSZ: 3.30
a_kSZ: 1.60
a_p: 6.90
beta_p: 2.08
a_c: 4.90
beta_c: 2.20
n_CIBC: 1.20
a_s: 3.10
T_d: 9.60
```