### PR TITLE
Support latest version of cobaya and remove deprecated material

### DIFF
--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -11,12 +11,12 @@ from typing import Optional
 
 import numpy as np
 from cobaya.conventions import _packages_path
-from cobaya.likelihoods._base_classes import _InstallableLikelihood
+from cobaya.likelihoods.base_classes import InstallableLikelihood
 from cobaya.log import LoggedError
 from cobaya.tools import are_different_params_lists
 
 
-class MFLike(_InstallableLikelihood):
+class MFLike(InstallableLikelihood):
     _url = "https://portal.nersc.gov/cfs/sobs/users/MFLike_data"
     _release = "v0.6"
     install_options = {"download_url": "{}/{}.tar.gz".format(_url, _release)}

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -36,7 +36,7 @@ class MFLikeTest(unittest.TestCase):
     def setUp(self):
         from cobaya.install import install
 
-        install({"likelihood": {"mflike.MFLike": None}}, path=packages_path, skip_global=True)
+        install({"likelihood": {"mflike.MFLike": None}}, path=packages_path)
 
     def test_mflike(self):
         import camb

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     python_requires=">=3.5",
     install_requires=[
         "fgspectra @ git+https://github.com/simonsobs/fgspectra@master#egg=fgspectra",
-        "cobaya>=3.0",
+        "cobaya>=3.0.4",
         "sacc>=0.4.2",
     ],
     package_data={"mflike": ["MFLike.yaml"]},


### PR DESCRIPTION
Underscore named class are now deprecated in cobaya 3.0.4