### PR TITLE
unused parameter removed

### DIFF
--- a/examples/mflike_example.yaml
+++ b/examples/mflike_example.yaml
@@ -93,9 +93,6 @@ params:
     latex: \sigma_8
 
   # Fixed values of nuisance
-  n_CIBC:
-    value: 1.20
-    latex: n_\mathrm{CIBC}
   T_d:
     value: 9.60
     latex: T_d

--- a/mflike/MFLike.yaml
+++ b/mflike/MFLike.yaml
@@ -175,12 +175,6 @@ params:
       max: 0.2
     proposal: 0.05
     latex: \xi
-  n_CIBC:
-    prior:
-      min: 1.0
-      max: 1.4
-    proposal: 0.045
-    latex: n_\mathrm{CIBC}
   T_d:
     prior:
       min:  8.60

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -58,7 +58,7 @@ class MFLike(InstallableLikelihood):
 
         self.expected_params_fg = ["a_tSZ", "a_kSZ", "a_p", "beta_p",
                                 "a_c", "beta_c", "a_s", "a_gtt", "a_gte", "a_gee",
-                                "a_psee", "a_pste","n_CIBC", "xi", "T_d"]
+                                "a_psee", "a_pste", "xi", "T_d"]
    
         self.expected_params_nuis = ["bandint_shift_93",
                                      "bandint_shift_145",


### PR DESCRIPTION
n_CIBC is not present in the current foreground model. This makes the presence of n_CIBC obsolete