### PR TITLE
Standalone fg model computation

### DIFF
--- a/mflike/MFLike.yaml
+++ b/mflike/MFLike.yaml
@@ -11,7 +11,7 @@ input_file: null
 # (The logic here is that you may have many different
 # realizations that share the same bandpowers and covariance)
 cov_Bbl_file: null
-
+standalone: False
 
 # Specify default set of spectra and scale cuts
 # to be used
@@ -63,8 +63,8 @@ data:
 # - bandwidth sets the relative width of the band wrt the central frequency
 #     with bandwidth: 0 no band integration is performed
 #     if bandwidth > 0 , nsteps must be > 1
-#     bandwidth can be a list if you want a different width for each band 
-#     e.g. bandwidth: [0.3,0.2,0.3] for 3 bands 
+#     bandwidth can be a list if you want a different width for each band
+#     e.g. bandwidth: [0.3,0.2,0.3] for 3 bands
 band_integration:
   external_bandpass: False
   nsteps: 1
@@ -87,10 +87,10 @@ foregrounds:
       - cibp
       - dust
       - radio
-    te: 
+    te:
       - radio
       - dust
-    ee: 
+    ee:
       - radio
       - dust
 

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -60,6 +60,7 @@ class MFLike(InstallableLikelihood):
         self.requested_cls = ["tt", "te", "ee"]
 
         self.l_bpws = None
+        self.freqs = None
         self.spec_meta = []
 
         self.expected_params_fg = ["a_tSZ", "a_kSZ", "a_p", "beta_p",
@@ -75,8 +76,8 @@ class MFLike(InstallableLikelihood):
                                      "calG_all",
                                      "alpha_93","alpha_145","alpha_225",
                                     ]
-        if not self.standalone:
-            self.ThFo = TheoryForge_MFLike(self)
+
+        self.ThFo = TheoryForge_MFLike(self)
         self.log.info("Initialized!")
 
     def initialize_with_params(self):
@@ -90,10 +91,7 @@ class MFLike(InstallableLikelihood):
                 differences)
 
     def get_requirements(self):
-        if not self.standalone:
-            return dict(Cl={k: max(c, self.lmax_theory+1) for k, c in self.lcuts.items()})
-        else:
-            return(dict())
+        return dict() if self.standalone else dict(Cl={k: max(c, self.lmax_theory+1) for k, c in self.lcuts.items()})
 
     def logp(self, **params_values):
         cl = self.theory.get_Cl(ell_factor=True)

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -28,39 +28,44 @@ class MFLike(InstallableLikelihood):
     foregrounds: dict
     band_integration: dict
     systematics_template: dict
+    standalone: bool
 
     def initialize(self):
-        # Set path to data
-        if ((not getattr(self, "path", None)) and
-                (not getattr(self, "packages_path", None))):
-            raise LoggedError(self.log,
-                              "No path given to MFLike data. "
-                              "Set the likelihood property "
-                              "'path' or the common property '%s'.",
-                              _packages_path)
-        # If no path specified, use the modules path
-        data_file_path = os.path.normpath(getattr(self, "path", None) or
-                                          os.path.join(self.packages_path,
-                                                       "data"))
 
-        self.data_folder = os.path.join(data_file_path, self.data_folder)
-        if not os.path.exists(self.data_folder):
-            raise LoggedError(
-                self.log, "The 'data_folder' directory does not exist. "
-                          "Check the given path [%s].", self.data_folder)
+        if not self.standalone:
+            # Set path to data
+            if ((not getattr(self, "path", None)) and
+                    (not getattr(self, "packages_path", None))):
+                raise LoggedError(self.log,
+                                  "No path given to MFLike data. "
+                                  "Set the likelihood property "
+                                  "'path' or the common property '%s'.",
+                                  _packages_path)
+            # If no path specified, use the modules path
+            data_file_path = os.path.normpath(getattr(self, "path", None) or
+                                              os.path.join(self.packages_path,
+                                                           "data"))
 
-        # Read data
-        self.prepare_data()
+            self.data_folder = os.path.join(data_file_path, self.data_folder)
+            if not os.path.exists(self.data_folder):
+                raise LoggedError(
+                    self.log, "The 'data_folder' directory does not exist. "
+                              "Check the given path [%s].", self.data_folder)
+
+            # Read data
+            self.prepare_data()
 
         # State requisites to the theory code
         self.lmax_theory = 9000
         self.requested_cls = ["tt", "te", "ee"]
 
+        self.l_bpws = None
+        self.spec_meta = []
 
         self.expected_params_fg = ["a_tSZ", "a_kSZ", "a_p", "beta_p",
                                 "a_c", "beta_c", "a_s", "a_gtt", "a_gte", "a_gee",
                                 "a_psee", "a_pste", "xi", "T_d"]
-   
+
         self.expected_params_nuis = ["bandint_shift_93",
                                      "bandint_shift_145",
                                      "bandint_shift_225",
@@ -70,8 +75,8 @@ class MFLike(InstallableLikelihood):
                                      "calG_all",
                                      "alpha_93","alpha_145","alpha_225",
                                     ]
-
-        self.ThFo = TheoryForge_MFLike(self)
+        if not self.standalone:
+            self.ThFo = TheoryForge_MFLike(self)
         self.log.info("Initialized!")
 
     def initialize_with_params(self):
@@ -85,7 +90,10 @@ class MFLike(InstallableLikelihood):
                 differences)
 
     def get_requirements(self):
-        return dict(Cl={k: max(c, self.lmax_theory+1) for k, c in self.lcuts.items()})
+        if not self.standalone:
+            return dict(Cl={k: max(c, self.lmax_theory+1) for k, c in self.lcuts.items()})
+        else:
+            return(dict())
 
     def logp(self, **params_values):
         cl = self.theory.get_Cl(ell_factor=True)
@@ -240,7 +248,6 @@ class MFLike(InstallableLikelihood):
             s_b.keep_indices(np.array(indices_b))
 
         # Now create metadata for each spectrum
-        self.spec_meta = []
         len_full = s.mean.size
         # These are the matrices we'll use to compress the data if
         # `symmetrize` is true.
@@ -252,7 +259,6 @@ class MFLike(InstallableLikelihood):
         self.lcuts = {k: c[1] for k, c in default_cuts["scales"].items()}
         index_sofar = 0
 
-        self.l_bpws = None
         for spectrum in data["spectra"]:
             (exp_1, exp_2, freq_1, freq_2,
              pols, scls, symm) = get_cl_meta(spectrum)
@@ -312,7 +318,7 @@ class MFLike(InstallableLikelihood):
                                                np.arange(cls.size,
                                                          dtype=int)),
                                        "pol": ppol_dict[pol],
-                                       "hasYX_xsp": pol in ["ET","BE","BT"], #This is necessary for handling symmetrization 
+                                       "hasYX_xsp": pol in ["ET","BE","BT"], #This is necessary for handling symmetrization
                                        "t1": xp_nu(exp_1, freq_1),  #
                                        "t2": xp_nu(exp_2, freq_2),  #
                                        "nu1": freq_1,
@@ -350,7 +356,7 @@ class MFLike(InstallableLikelihood):
             p = m["pol"]
             i = m["ids"]
             w = m["bpw"].weight.T
-            clt = np.dot(w, DlsObs[p, m["nu1"], m["nu2"]])       
+            clt = np.dot(w, DlsObs[p, m["nu1"], m["nu2"]])
             ps_vec[i] = clt
 
         return ps_vec

--- a/mflike/theoryforge_MFLike.py
+++ b/mflike/theoryforge_MFLike.py
@@ -138,16 +138,13 @@ class TheoryForge_MFLike:
 
 
     #Gets the actual power spectrum of foregrounds given the passed parameters
-    def _get_foreground_model(self, ell = None, bandint_freqs = None, **fg_params):
+    def _get_foreground_model(self, ell = None, **fg_params):
         #if ell = None, it uses the l_bpws, otherwise the ell array provided
         #useful to make tests at different l_max than the data
         if not hasattr(ell,'__len__'):
             ell = self.l_bpws
         ell_0 = self.fg_ell_0
         nu_0 = self.fg_nu_0
-
-        if bandint_freqs is not None:
-            self.bandint_freqs = bandint_freqs
 
         # Normalisation of radio sources
         ell_clp = ell*(ell+1.)


### PR DESCRIPTION
Add a "standalone" option for the LAT_MFLike likelihood.
It allows the use of the likelihood (to compute the foreground model in maps2params) without downloading the data.

This pull request is associated with this one from PSpipe [simonsobs/PSpipe/pull/87]