### PR TITLE
Fix data release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,9 @@ directory.
 Simulation releases
 -------------------
 
+- ``v0.7.1`` is a bugfix release of ``v0.7`` release where the mono-frequency and dirac bandpasses
+  have been correctly set with the ``sacc`` files
+
 - ``v0.7`` release includes the ACT like foregrounds. Simulation parameters are also stored within ``sacc`` metadata and the associated ``dict`` file can be viewed `here <https://gist.github.com/xgarrido/5d2fdbe4232cfa9ad1156ee30baa7811>`_.
 
 - ``v0.6`` release make use of CMB map based simulations (see https://github.com/simonsobs/map_based_simulations/blob/master/201911_lensed_cmb/README.md). Only temperature foregrounds were considered.

--- a/mflike/MFLike.yaml
+++ b/mflike/MFLike.yaml
@@ -1,6 +1,6 @@
 # A simple cobaya likelihood for SO/LAT
 
-data_folder: MFLike/v0.7
+data_folder: MFLike/v0.7.1
 # Path to the input SACC file, containing, minimally,
 # information about the different tracers (i.e. frequency
 # bands) and the set of power spectra.

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -20,7 +20,7 @@ from .theoryforge_MFLike import TheoryForge_MFLike
 
 class MFLike(InstallableLikelihood):
     _url = "https://portal.nersc.gov/cfs/sobs/users/MFLike_data"
-    _release = "v0.7"
+    _release = "v0.7.1"
     install_options = {"download_url": f"{_url}/{_release}.tar.gz"}
 
     # attributes set from .yaml


### PR DESCRIPTION
The v0.7.1 simulation release is a bugfix release where the frequency and bandpass values have been
correctly set. This fix is related to this PR https://github.com/simonsobs/PSpipe/pull/121

It will have no impact on previous or forthcoming simulation analysis.
