### PR TITLE
Prepare mflike for pypi release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,45 @@
+name: Build wheels and upload to PyPI
+
+on: [push, pull_request]
+
+jobs:
+
+  build_dist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: '3.X'
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install wheel
+          python setup.py sdist bdist_wheel
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*
+          retention-days: 1
+
+  upload_pypi:
+    needs: [build_dist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          # To test: repository_url: https://test.pypi.org/legacy/

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,11 @@ LAT Multifrequency Likelihood
 
 An external likelihood using `cobaya <https://github.com/CobayaSampler/cobaya>`_.
 
+.. image:: https://img.shields.io/pypi/v/mflike.svg?style=flat
+   :target: https://pypi.python.org/pypi/mflike
+
 .. image:: https://img.shields.io/github/actions/workflow/status/simonsobs/LAT_MFLike/testing.yml?branch=master
    :target: https://github.com/simonsobs/LAT_MFLike/actions
-   :alt: GitHub Workflow Status
 
 .. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/simonsobs/LAT_MFLike/master?filepath=notebooks%2Fmflike_tutorial.ipynb
@@ -19,7 +21,13 @@ An external likelihood using `cobaya <https://github.com/CobayaSampler/cobaya>`_
 Installing the code
 -------------------
 
-You first need to clone this repository to some location
+The easiest way to install and to use ``mflike`` likelihood is *via* ``pip``
+
+.. code:: shell
+
+    pip install mflike
+
+If you want to dig into the code, you'd better clone this repository to some location
 
 .. code:: shell
 

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -15,7 +15,7 @@ from cobaya.likelihoods.base_classes import InstallableLikelihood
 from cobaya.log import LoggedError
 from cobaya.tools import are_different_params_lists
 
-from .theoryforge_MFLike import TheoryForge_MFLike
+from .theoryforge import TheoryForge
 
 
 class MFLike(InstallableLikelihood):
@@ -33,7 +33,6 @@ class MFLike(InstallableLikelihood):
     systematics_template: dict
 
     def initialize(self):
-
         # Set default values to data member not initialized via yaml file
         self.l_bpws = None
         self.freqs = None
@@ -94,7 +93,7 @@ class MFLike(InstallableLikelihood):
                 f"alpha_{f}",
             ]
 
-        self.ThFo = TheoryForge_MFLike(self)
+        self.ThFo = TheoryForge(self)
         self.log.info("Initialized!")
 
     def initialize_with_params(self):

--- a/mflike/theoryforge.py
+++ b/mflike/theoryforge.py
@@ -16,9 +16,8 @@ def _cmb2bb(nu):
     return np.exp(x) * (nu * x / np.expm1(x)) ** 2
 
 
-class TheoryForge_MFLike:
+class TheoryForge:
     def __init__(self, mflike=None):
-
         if mflike is None:
             import logging
 
@@ -55,7 +54,7 @@ class TheoryForge_MFLike:
 
             # Parameters for template from file
             self.use_systematics_template = bool(mflike.systematics_template)
-            
+
             if self.use_systematics_template:
                 self.systematics_template = mflike.systematics_template
                 # Initialize template for marginalization, if needed
@@ -127,7 +126,6 @@ class TheoryForge_MFLike:
             self.bandint_freqs = np.asarray(self.bandint_freqs)
 
     def get_modified_theory(self, Dls, **params):
-
         fg_params = {k: params[k] for k in self.expected_params_fg}
         nuis_params = {k: params[k] for k in self.expected_params_nuis}
 
@@ -184,7 +182,6 @@ class TheoryForge_MFLike:
 
     # Initializes the foreground model. It sets the SED and reads the templates
     def _init_foreground_model(self):
-
         from fgspectra import cross as fgc
         from fgspectra import frequency as fgf
         from fgspectra import power as fgp
@@ -334,7 +331,6 @@ class TheoryForge_MFLike:
     ###########################################################################
 
     def _get_calibrated_spectra(self, dls_dict, **nuis_params):
-
         from syslibrary import syslib_mflike as syl
 
         cal_pars = {}
@@ -360,7 +356,6 @@ class TheoryForge_MFLike:
     ###########################################################################
 
     def _get_rotated_spectra(self, dls_dict, **nuis_params):
-
         from syslibrary import syslib_mflike as syl
 
         rot_pars = [nuis_params[f"alpha_{exp}"] for exp in self.experiments]
@@ -389,7 +384,6 @@ class TheoryForge_MFLike:
         self.dltempl_from_file = templ_from_file(ell=self.l_bpws)
 
     def _get_template_from_file(self, dls_dict, **nuis_params):
-
         # templ_pars=[nuis_params['templ_'+str(exp)] for exp in self.experiments]
         # templ_pars currently hard-coded
         # but ideally should be passed as input nuisance

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(
     packages=find_packages(),
     python_requires=">=3.5",
     install_requires=[
-        "fgspectra @ git+https://github.com/simonsobs/fgspectra@act_sz_x_cib#egg=fgspectra",
-        "syslibrary @ git+https://github.com/simonsobs/syslibrary@master#egg=syslibrary",
+        "fgspectra>=1.1.0",
+        "syslibrary>=0.1.0",
         "cobaya>=3.1.0",
         "sacc>=0.4.2",
     ],


### PR DESCRIPTION
- change `setup.py` to explicitly use modules from pypi (fgspectra and syslib)
- add wheel github actions to automatically push new tag release to pypi
- change theory forge name by removing reference to `mflike` in the name since it is imported from `mflike` just like 
```python 
from mflike import theoryforge 
```