### PR TITLE
correct bandpass construction in the presence of shifts

### DIFF
--- a/mflike/MFLike.yaml
+++ b/mflike/MFLike.yaml
@@ -71,6 +71,7 @@ data:
 # (if bandpass in sacc is a single freq, no band integration)
 # the default is to read bandpasses from file, to build top-hat uncomment the
 # parameters of the block!
+# Bandpass has to be in RJ units
 top_hat_band:
 #  nsteps: 1
 #  bandwidth: 0

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -158,8 +158,8 @@ class MFLikeTest(unittest.TestCase):
 
         # chi2 reference results for the different models and different bandshifts
         chi2s = {
-            "model1": [2265.168, 3742.528, 43753.810],
-            "model2": [2345.508, 4224.293, 41764.366],
+            "model1": [2265.168, 3742.528, 43753.809],
+            "model2": [2345.508, 4458.148, 47533.477],
         }
 
         for model, chi2 in chi2s.items():


### PR DESCRIPTION
There is a mistake in the current construction of the transmission from the bandpasses, **in the presence of bandpass shift**. 
In the current version we are doing:

> `nub = nu_ghz + params[bandpar]`  <--- freqs nu_ghz shifted by params['bandpass_shift'] sampled by cobaya
`trans_norm = np.trapz(bp * _cmb2bb(nu_ghz), nu_ghz)`    <--- integral of the bandpass bp and the conversion factor from cmb to brightness temperature 
`trans = bp / trans_norm * _cmb2bb(nub)`  <--- trasmission normalized by the integral trans_norm
`self.bandint_freqs.append([nub, trans])`


while we should do:

> `nub = nu_ghz + params[bandpar]`
`trans_norm = np.trapz(bp * _cmb2bb(nub), nub)`
`trans = bp / trans_norm * _cmb2bb(nub) `
`self.bandint_freqs.append([nub, trans])`


so we should use the shifted frequency array `nub` both at the numerator and the denominator of `trans`
This way, we assume that the cmb component would always have `trans` = 1 (since the cmb component can come out of the integral and the numerator and denominator can simplify)
This is implicitly what we are already doing [by summing the cmb theory spectra to the foreground spectra](https://github.com/simonsobs/LAT_MFLike/blob/c82626948fd3c81dc27f5e510ad346cef9999a74/mflike/theoryforge.py#L149) integrated in band:
 `
cmbfg_dict[s, exp1, exp2] = Dls[s] + fg_dict[s, "all", exp1, exp2]
`

The current version works fine when `bandpass_shifts = 0`.