### PR TITLE
TE/ET fix

### DIFF
--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -357,7 +357,9 @@ class MFLike(InstallableLikelihood):
             p = m["pol"]
             i = m["ids"]
             w = m["bpw"].weight.T
-            clt = w @ DlsObs[p, m["t1"], m["t2"], m["hasYX_xsp"]]
+            dls_obs = DlsObs[p, m["t1"], m["t2"]]
+            if m["hasYX_xsp"]: dls_obs = DlsObs[p, m["t2"], m["t1"]]
+            clt = w @ DlsObs[p, m["t1"], m["t2"]]
             ps_vec[i] = clt
 
         return ps_vec

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -359,7 +359,7 @@ class MFLike(InstallableLikelihood):
             w = m["bpw"].weight.T
             dls_obs = DlsObs[p, m["t1"], m["t2"]]
             if m["hasYX_xsp"]: dls_obs = DlsObs[p, m["t2"], m["t1"]]
-            clt = w @ DlsObs[p, m["t1"], m["t2"]]
+            clt = w @ dls_obs
             ps_vec[i] = clt
 
         return ps_vec

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -286,7 +286,9 @@ class MFLike(InstallableLikelihood):
                     # will all be sampled at the same ells.
                     self.l_bpws = ws.values
 
-                # Symmetrize if needed.
+                # Symmetrize if needed. If symmetrize = True, the "ET" polarization
+                # is eliminated by the polarization list and the TE spectrum becomes
+                # (TE + ET)/2. The associated spec_meta dict will have "hasYX_xsp": False
                 if (pol in ["TE", "ET"]) and symm:
                     pol2 = pol[::-1]
                     pols.remove(pol2)
@@ -315,8 +317,8 @@ class MFLike(InstallableLikelihood):
                     {
                         "ids": (index_sofar + np.arange(cls.size, dtype=int)),
                         "pol": ppol_dict[pol],
-                        "hasYX_xsp": pol
-                        in ["ET", "BE", "BT"],  # This is necessary for handling symmetrization
+                        "hasYX_xsp": pol        # this flag is true for pol = TE, BE, BT
+                        in ["ET", "BE", "BT"],  
                         "t1": exp_1,
                         "t2": exp_2,
                         "leff": ls,  #
@@ -358,6 +360,11 @@ class MFLike(InstallableLikelihood):
             i = m["ids"]
             w = m["bpw"].weight.T
             dls_obs = DlsObs[p, m["t1"], m["t2"]]
+            # If symmetrize = False, the (ET, exp1, exp2) spectrum 
+            # will have the flag m["hasYX_xsp"] = True. 
+            # In this case, the power spectrum
+            # is computed as DlsObs["te", m["t2"], m["t1"]], to associate
+            # T --> exp2, E --> exp1
             if m["hasYX_xsp"]: dls_obs = DlsObs[p, m["t2"], m["t1"]]
             clt = w @ dls_obs
             ps_vec[i] = clt

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -357,7 +357,7 @@ class MFLike(InstallableLikelihood):
             p = m["pol"]
             i = m["ids"]
             w = m["bpw"].weight.T
-            clt = w @ DlsObs[p, m["t1"], m["t2"]]
+            clt = w @ DlsObs[p, m["t1"], m["t2"], m["hasYX_xsp"]]
             ps_vec[i] = clt
 
         return ps_vec

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -359,13 +359,12 @@ class MFLike(InstallableLikelihood):
             p = m["pol"]
             i = m["ids"]
             w = m["bpw"].weight.T
-            dls_obs = DlsObs[p, m["t1"], m["t2"]]
             # If symmetrize = False, the (ET, exp1, exp2) spectrum 
             # will have the flag m["hasYX_xsp"] = True. 
             # In this case, the power spectrum
             # is computed as DlsObs["te", m["t2"], m["t1"]], to associate
             # T --> exp2, E --> exp1
-            if m["hasYX_xsp"]: dls_obs = DlsObs[p, m["t2"], m["t1"]]
+            dls_obs = DlsObs[p, m["t2"], m["t1"]] if m["hasYX_xsp"] else DlsObs[p, m["t1"], m["t2"]]
             clt = w @ dls_obs
             ps_vec[i] = clt
 

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -317,7 +317,7 @@ class MFLike(InstallableLikelihood):
                     {
                         "ids": (index_sofar + np.arange(cls.size, dtype=int)),
                         "pol": ppol_dict[pol],
-                        "hasYX_xsp": pol        # this flag is true for pol = TE, BE, BT
+                        "hasYX_xsp": pol        # this flag is true for pol = ET, BE, BT
                         in ["ET", "BE", "BT"],  
                         "t1": exp_1,
                         "t2": exp_2,

--- a/mflike/theoryforge.py
+++ b/mflike/theoryforge.py
@@ -174,16 +174,16 @@ class TheoryForge:
         for m in self.spec_meta:
             p = m["pol"]
             if p in ["tt", "ee", "bb"]:
-                dls_dict[p, m["t1"], m["t2"]] = cmbfg_dict[p, m["t1"], m["t2"]]
+                dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t1"], m["t2"]]
             else:  # ['te','tb','eb']
                 if m["hasYX_xsp"]:  # not symmetrizing
-                    dls_dict[p, m["t1"], m["t2"]] = cmbfg_dict[p, m["t2"], m["t1"]]
+                    dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t2"], m["t1"]]
                 else:
-                    dls_dict[p, m["t1"], m["t2"]] = cmbfg_dict[p, m["t1"], m["t2"]]
+                    dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t1"], m["t2"]]
 
                 if self.defaults_cuts["symmetrize"]:  # we average TE and ET (as we do for data)
-                    dls_dict[p, m["t1"], m["t2"]] += cmbfg_dict[p, m["t2"], m["t1"]]
-                    dls_dict[p, m["t1"], m["t2"]] *= 0.5
+                    dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] += cmbfg_dict[p, m["t2"], m["t1"]]
+                    dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] *= 0.5
 
         return dls_dict
 

--- a/mflike/theoryforge.py
+++ b/mflike/theoryforge.py
@@ -177,7 +177,7 @@ class TheoryForge:
                 dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t1"], m["t2"]]
             else:  # ['te','tb','eb']
                 if m["hasYX_xsp"]:  # not symmetrizing
-                    dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t2"], m["t1"]]
+                    dls_dict[p, m["t2"], m["t1"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t2"], m["t1"]]
                 else:
                     dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t1"], m["t2"]]
 

--- a/mflike/theoryforge.py
+++ b/mflike/theoryforge.py
@@ -174,16 +174,16 @@ class TheoryForge:
         for m in self.spec_meta:
             p = m["pol"]
             if p in ["tt", "ee", "bb"]:
-                dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t1"], m["t2"]]
+                dls_dict[p, m["t1"], m["t2"]] = cmbfg_dict[p, m["t1"], m["t2"]]
             else:  # ['te','tb','eb']
                 if m["hasYX_xsp"]:  # not symmetrizing
-                    dls_dict[p, m["t2"], m["t1"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t2"], m["t1"]]
+                    dls_dict[p, m["t2"], m["t1"]] = cmbfg_dict[p, m["t2"], m["t1"]]
                 else:
-                    dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] = cmbfg_dict[p, m["t1"], m["t2"]]
+                    dls_dict[p, m["t1"], m["t2"]] = cmbfg_dict[p, m["t1"], m["t2"]]
 
                 if self.defaults_cuts["symmetrize"]:  # we average TE and ET (as we do for data)
-                    dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] += cmbfg_dict[p, m["t2"], m["t1"]]
-                    dls_dict[p, m["t1"], m["t2"], m["hasYX_xsp"]] *= 0.5
+                    dls_dict[p, m["t1"], m["t2"]] += cmbfg_dict[p, m["t2"], m["t1"]]
+                    dls_dict[p, m["t1"], m["t2"]] *= 0.5
 
         return dls_dict
 

--- a/mflike/theoryforge.py
+++ b/mflike/theoryforge.py
@@ -176,12 +176,16 @@ class TheoryForge:
             if p in ["tt", "ee", "bb"]:
                 dls_dict[p, m["t1"], m["t2"]] = cmbfg_dict[p, m["t1"], m["t2"]]
             else:  # ['te','tb','eb']
-                if m["hasYX_xsp"]:  # not symmetrizing
+                if m["hasYX_xsp"]:  # case with symmetrize = False and ET/BT/BE spectra
                     dls_dict[p, m["t2"], m["t1"]] = cmbfg_dict[p, m["t2"], m["t1"]]
-                else:
+                else: # case of TE/TB/EB spectra, or symmetrize = True
                     dls_dict[p, m["t1"], m["t2"]] = cmbfg_dict[p, m["t1"], m["t2"]]
 
-                if self.defaults_cuts["symmetrize"]:  # we average TE and ET (as we do for data)
+                # if symmetrize = True, dls_dict has already been set 
+                # equal to cmbfg_dict[p, m["t1"], m["t2"]
+                # now we add cmbfg_dict[p, m["t2"], m["t1"] and we average them
+                # as we do for our data
+                if self.defaults_cuts["symmetrize"]:  
                     dls_dict[p, m["t1"], m["t2"]] += cmbfg_dict[p, m["t2"], m["t1"]]
                     dls_dict[p, m["t1"], m["t2"]] *= 0.5
 


### PR DESCRIPTION
Fixing the way cross-frequencies spectra are handled in MFLIKE. We noticed the T_nu1 x E_nu2 was stored in the same entry as T_nu2 x E_nu1 during theory building. While this is fine for CMB+FG, it isn't for calibration. Here is a quickfix, that explicitely store `dls_dict[p, m["t2"], m["t1"]]` (instead of `dls_dict[p, m["t1"], m["t2"]]`) in the case of 'ET' spectra.

We might want to do differently in the future but this should handle all the cases we can think of. 

Also added some comments to document !