### PR TITLE
Changes in calibration to reflect ones made in syslib

### DIFF
--- a/mflike/theoryforge.py
+++ b/mflike/theoryforge.py
@@ -353,13 +353,13 @@ class TheoryForge:
             cal = nuis_params["calG_all"] * np.array(
                 [nuis_params[f"cal_{exp}"] * nuis_params[f"calT_{exp}"] for exp in self.experiments]
             )
-            cal_pars["tt"] = 1 / cal
+            cal_pars["t"] = 1 / cal
 
         if "ee" in self.requested_cls or "te" in self.requested_cls:
             cal = nuis_params["calG_all"] * np.array(
                 [nuis_params[f"cal_{exp}"] * nuis_params[f"calE_{exp}"] for exp in self.experiments]
             )
-            cal_pars["ee"] = 1 / cal
+            cal_pars["e"] = 1 / cal
 
         calib = syl.Calibration_alm(ell=self.l_bpws, spectra=dls_dict)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     ],
     install_requires=[
         "fgspectra>=1.1.0",
-        "syslibrary>=0.1.0",
+        "syslibrary>=0.2.0",
         "cobaya>=3.4.1",
         "sacc>=0.9.0",
     ],


### PR DESCRIPTION
Changing the keys to cal_pars to reflect the fact that they are a_lm (or map) level calibraation. This is now more consistent and makes with what has been changed to syslibrary here: https://github.com/simonsobs/syslibrary/pull/17