### PR TITLE
Fix missing version number

### DIFF
--- a/mflike/__init__.py
+++ b/mflike/__init__.py
@@ -1,4 +1,9 @@
 from .mflike import MFLike
 from .theoryforge import TheoryForge
+from importlib.metadata import version, PackageNotFoundError
 
-from ._version import __version__
+try:
+    __version__ = version("mflike")
+except PackageNotFoundError:
+    # package is not installed
+    pass


### PR DESCRIPTION
In case the package is not installed (for instance with readthedocs) or installed from source with no `.git` directory (for instance downloaded as tarball), the initialisation process will fail.

See https://setuptools-scm.readthedocs.io/en/latest/usage/#version-at-runtime