### PR TITLE
Simpler calibration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12"
 ]
 requires-python = ">=3.9.0"
 dependencies = [


### PR DESCRIPTION
I found the calibration code quite hard to understand, esp. why per likelihood it was instantiating a "residual" class in a systematics library. This just does it directly (assuming I correctly understood the original..). Rotation_alm is then not needed, and should also be faster/many fewer temporary memory allocations.