### PR TITLE
Parameters defaults etc

### DIFF
--- a/mflike/theoryforge.py
+++ b/mflike/theoryforge.py
@@ -361,7 +361,7 @@ class TheoryForge:
         The computation assumes the bandpass transmissions computed in ``_bandpass_construction``
         and integration in frequency is performed if the passbands are not Dirac delta.
 
-        :param g_params: parameters of the foreground components
+        :param fg_params: parameters of the foreground components
         :param ell: ell range. If ``None`` the default range
             set in ``mflike.l_bpws`` is used
 

--- a/mflike/theoryforge.py
+++ b/mflike/theoryforge.py
@@ -616,17 +616,17 @@ class TheoryForge:
     def _init_template_from_file(self):
         """
         Reads the systematics template from file, using
-        the ``syslibrary.syslib_mflike.ReadTemplateFromFile``
+        the ``syslibrary.syslib.ReadTemplateFromFile``
         function.
         """
         if not self.systematics_template.get("rootname"):
             raise LoggedError(self.log, "Missing 'rootname' for systematics template!")
 
-        from syslibrary import syslib_mflike as syl
+        from syslibrary import syslib
 
         # decide where to store systematics template.
         # Currently stored inside syslibrary package
-        templ_from_file = syl.ReadTemplateFromFile(rootname=self.systematics_template["rootname"])
+        templ_from_file = syslib.ReadTemplateFromFile(rootname=self.systematics_template["rootname"])
         self.dltempl_from_file = templ_from_file(ell=self.l_bpws)
 
     def _get_template_from_file(self, dls_dict, **nuis_params):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12"
 ]
 requires-python = ">=3.9.0"
 dependencies = [


### PR DESCRIPTION
Building on other PRs (i.e. just last commit for PR-specific changes), and trying to make a bit closer to SOlikeT version, I reorganised some of the parameter handling. A lot of the testing should I think be done by Cobaya, so should still get error messages etc if something is wrong.

This separates out loglike() as a separate (non-Cobaya) function, but avoids duplication of all the parameter names in the yaml and code.