### PR TITLE
fixing the chi2 value printed in MFLike

### DIFF
--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -143,7 +143,7 @@ class _MFLike(InstallableLikelihood):
         # logp = -0.5 * (delta @ self.inv_cov @ delta)
         chi2 = self._fast_chi_squared(self.inv_cov, delta)
         logp = -0.5 * chi2 + self.logp_const
-        self.log.debug(f"Log-likelihood value computed = {logp} (Χ² = {-2 * chi2})")
+        self.log.debug(f"Log-likelihood value computed = {logp} (Χ² = {chi2})")
         return logp
 
     def loglike(self, cl, fg_totals, **params_values):


### PR DESCRIPTION
In [the line](https://github.com/simonsobs/LAT_MFLike/blob/894e3f30cdeb630aa88fef9eb0500c6212d9ce8a/mflike/mflike.py#L146C72-L146C81) where we print the logp and the chi2, we have
```
chi2 = self._fast_chi_squared(self.inv_cov, delta)
logp = -0.5 * chi2 + self.logp_const
self.log.debug(f"Log-likelihood value computed = {logp} (Χ² = {-2 * chi2})")
```
so we print -2 chi2 instead of chi2. The extra -2 is a leftover factor from a previous implementation, see the version before [this commit](https://github.com/simonsobs/LAT_MFLike/commit/69d91befcb7561079854e472b4d2277207935ce1).
So I just removed the extra -2