### PR TITLE
Internal parameter covariance functionality.

### DIFF
--- a/mflike/_MFLike.yaml
+++ b/mflike/_MFLike.yaml
@@ -48,5 +48,14 @@ systematics_template:
 # If you want to have some parameters be correlated, include the path to a 
 # parameter covmat here. You can uncomment the example lines to try it out.
 parameter_covariance:
-#  mean: calib_mean.txt
+# The covmat can either be provided as a full path, or as the name of a file
+# found in the same directory as mflike.py. It should have one comment line at
+# the start that lists the names of the parameters, followed by a dense covariance
+# matrix.
 #  cov: calib_cov.txt
+
+# For the mean, you can either provide a file in a similar format as the covariance
+# matrix (being only one line of means for each of the values), or you can provide
+# a numeric value that will be used for all the means of the parameters listed
+# in the covmat file.
+#  mean: calib_mean.txt

--- a/mflike/_MFLike.yaml
+++ b/mflike/_MFLike.yaml
@@ -45,3 +45,8 @@ data:
 systematics_template:
 #  rootname: "test_template"
 
+# If you want to have some parameters be correlated, include the path to a 
+# parameter covmat here. You can uncomment the example lines to try it out.
+parameter_covariance:
+#  mean: calib_mean.txt
+#  cov: calib_cov.txt

--- a/mflike/calib_cov.txt
+++ b/mflike/calib_cov.txt
@@ -1,0 +1,4 @@
+# cal_LAT_93 cal_LAT_145 cal_LAT_225
+1e-4 1e-6 1e-8
+1e-6 1e-4 1e-6
+1e-8 1e-6 1e-4

--- a/mflike/calib_mean.txt
+++ b/mflike/calib_mean.txt
@@ -1,0 +1,2 @@
+# cal_LAT_93 cal_LAT_145 cal_LAT_225
+1 1 1

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -750,10 +750,14 @@ class _MFLike(InstallableLikelihood):
             assert len(means) == len(parameters), \
                    "Number of parameters in means file does not match covmat size."
 
+        logp_const = np.log(2 * np.pi) * (-len(means) / 2) - 0.5 * np.linalg.slogdet(cov)[1]
+        self.logp_const += logp_const
+
         self.parameter_covariance = {
             "params": parameters,
             "mean": means,
-            "inv_cov": inv_cov
+            "inv_cov": inv_cov,
+            "logp_const": logp_const,
         }
 
         self.log.debug(f"Loaded parameter covariance for parameters {parameters}.")

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -738,9 +738,10 @@ class _MFLike(InstallableLikelihood):
 
         if type(meanfile) in [int, float, np.ndarray]:
             means = np.array(meanfile) * np.ones_like(np.diag(cov))
-        elif not os.path.exists(meanfile):
-            meanfile = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                                    meanfile)
+        else:
+            if not os.path.exists(meanfile):
+                meanfile = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                        meanfile)
 
             if not os.path.exists(meanfile):
                 raise IOError(f"Cannot load means from {meanfile}: does not exist.")

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -39,6 +39,22 @@ The values of the systematic parameters are set in the
 ``TTTEEE/TTTE/TT/EE/TE/etc.yaml`` files corresponding to the classes that inherit the
 ``_MFLike`` one.  They have to be named as
 ``cal/calT/calE/alpha`` + ``_`` + experiment_channel string (e.g. ``LAT_93/dr6_pa4_f150``).
+
+If these parameters are expected to be correlated, you can add a joint multivariate
+Gaussian likelihood on these parameters with the settings block:
+
+.. code-block:: yaml
+
+  parameter_covariance:
+    cov: param_cov.txt
+    mean: param_mean.txt
+
+where the `cov` and `mean` files contain a single commented line with the names of
+the parameters that are to be included in this likelihood. You can also set the
+`mean` to a single value, for example `mean: 1`, which will set the mean for all
+these parameters to this value.
+
+If you do this, do take care not to set the prior on these parameters in cobaya twice.
 """
 
 import os

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -42,6 +42,7 @@ The values of the systematic parameters are set in the
 """
 
 import os
+from typing import Optional
 from numbers import Real
 
 import numpy as np
@@ -60,15 +61,16 @@ class _MFLike(InstallableLikelihood):
     }
 
     # attributes set from .yaml
-    input_file: str | None
-    cov_Bbl_file: str | None
+    input_file: Optional[str]
+    cov_Bbl_file: Optional[str]
     data_folder: str
     data: dict
     defaults: dict
     systematics_template: dict
     supported_params: dict
-    lmax_theory: int | None
+    lmax_theory: Optional[int]
     requested_cls: list[str]
+    parameter_covariance: Optional[dict]
 
     def initialize(self):
         # Set default values to data member not initialized via yaml file
@@ -105,6 +107,9 @@ class _MFLike(InstallableLikelihood):
             # Initialize template for marginalization, if needed
             self._init_template_from_file()
 
+        if self.parameter_covariance:
+            self._init_parameter_covariance()
+
         self._constant_nuisance: dict | None = None
         self.log.info("Initialized!")
 
@@ -134,6 +139,7 @@ class _MFLike(InstallableLikelihood):
     def logp(self, **params_values) -> float:
         cl = self.provider.get_Cl(ell_factor=True)
         fg_totals = self.provider.get_fg_totals()
+
         return self._loglike(cl, fg_totals, params_values)
 
     def _loglike(self, cl: dict, fg_totals: list, params_values: dict) -> float:
@@ -152,6 +158,15 @@ class _MFLike(InstallableLikelihood):
         chi2 = self._fast_chi_squared(self.inv_cov, delta)
         logp = -0.5 * chi2 + self.logp_const
         self.log.debug(f"Log-likelihood value computed = {logp} (Χ² = {chi2})")
+
+        if self.parameter_covariance:
+            par_vec = np.array([ params_values[p] for p in self.parameter_covariance["params"] ])
+            delta = self.parameter_covariance["mean"] - par_vec
+            par_logp = self._fast_chi_squared(self.parameter_covariance["inv_cov"], delta)
+            chi2 = -0.5 * par_logp
+            self.log.debug(f"Parameter log-likelihood = {par_logp} (Χ² = {chi2})")
+            logp += par_logp
+
         return logp
 
     def loglike(self, cl: dict, fg_totals: list, **params_values) -> float:
@@ -683,6 +698,48 @@ class _MFLike(InstallableLikelihood):
         # Currently stored inside syslibrary package
         templ_from_file = syslib.ReadTemplateFromFile(rootname=root)
         self.dltempl_from_file = templ_from_file(ell=self.l_bpws)
+
+    def _init_parameter_covariance(self):
+        meanfile, covfile = self.parameter_covariance["mean"], self.parameter_covariance["cov"]
+
+        if not os.path.exists(covfile):
+            covfile = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                   covfile)
+
+            if not os.path.exists(covfile):
+                raise IOError(f"Parameter covariance file {covfile} does not exist.")
+
+        with open(covfile, "r") as fp:
+            parameters = fp.readline().strip().split(" ")[1:]
+
+        cov = np.loadtxt(covfile)
+        assert cov.shape[0] == cov.shape[1], \
+               "Parameter covariance matrix not square."
+        assert cov.shape[0] == len(parameters), \
+               "Number of parameters does not match covmat size."
+
+        inv_cov = np.linalg.inv(cov)
+
+        if type(meanfile) in [int, float, np.ndarray]:
+            means = np.array(meanfile) * np.ones_like(np.diag(cov))
+        elif not os.path.exists(meanfile):
+            meanfile = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                    meanfile)
+
+            if not os.path.exists(meanfile):
+                raise IOError(f"Cannot load means from {meanfile}: does not exist.")
+
+            means = np.loadtxt(meanfile)
+            assert len(means) == len(parameters), \
+                   "Number of parameters in means file does not match covmat size."
+
+        self.parameter_covariance = {
+            "params": parameters,
+            "mean": means,
+            "inv_cov": inv_cov
+        }
+
+        self.log.debug(f"Loaded parameter covariance for parameters {parameters}.")
 
     def _get_template_from_file(self, dls_dict: dict, **nuis_params) -> dict:
         r"""

--- a/mflike/mflike.py
+++ b/mflike/mflike.py
@@ -162,8 +162,8 @@ class _MFLike(InstallableLikelihood):
         if self.parameter_covariance:
             par_vec = np.array([ params_values[p] for p in self.parameter_covariance["params"] ])
             delta = self.parameter_covariance["mean"] - par_vec
-            par_logp = self._fast_chi_squared(self.parameter_covariance["inv_cov"], delta)
-            chi2 = -0.5 * par_logp
+            chi2 = self._fast_chi_squared(self.parameter_covariance["inv_cov"], delta)
+            par_logp = -0.5 * chi2
             self.log.debug(f"Parameter log-likelihood = {par_logp} (Χ² = {chi2})")
             logp += par_logp
 

--- a/mflike/tests/example_cov.txt
+++ b/mflike/tests/example_cov.txt
@@ -1,0 +1,4 @@
+# cal_LAT_93 cal_LAT_145 cal_LAT_225
+1e-4 0 0
+0 1e-4 0
+0 0 1e-4

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -423,3 +423,42 @@ class MFLikeTest(unittest.TestCase):
 
             chi2_mflike = -2 * (model.loglike(new_params, return_derived=False) - logp_const)
             self.assertAlmostEqual(chi2_mflike, chi2[i], 2)
+
+    def test_calibration_correlation(self):
+        import camb
+
+        from mflike import TTTEEE, BandpowerForeground
+
+        # using camb low accuracy parameters for the test
+        camb_cosmo = cosmo_params | {"lmax": 9001, "lens_potential_accuracy": 1}
+        pars = camb.set_params(**camb_cosmo)
+        nuis_params = common_nuis_params | TT_nuis_params | TE_nuis_params | EE_nuis_params
+        results = camb.get_results(pars)
+        powers = results.get_cmb_power_spectra(pars, CMB_unit="muK")
+        cl_dict = {k: powers["total"][:, v] for k, v in {"tt": 0, "ee": 1, "te": 3}.items()}
+        my_mflike = TTTEEE(
+            {
+                "packages_path": packages_path,
+                "input_file": pre + "00000.fits",
+                "cov_Bbl_file": "data_sacc_w_covar_and_Bbl.fits",
+                "defaults": {
+                    "polarizations": ["TT", "TE", "ET", "EE"],
+                    "scales": {
+                        "TT": [30, 9000],
+                        "TE": [30, 9000],
+                        "ET": [30, 9000],
+                        "EE": [30, 9000],
+                    },
+                    "symmetrize": False,
+                },
+                "parameter_covariance": {
+                    "mean": 1,
+                    "cov": "calib_cov.txt"
+                }
+            }
+        )
+        fg = BandpowerForeground(my_mflike.get_fg_requirements())
+        fg_totals = fg.get_foreground_model_totals(**nuis_params)
+
+        loglike = my_mflike.loglike(cl_dict, fg_totals, **nuis_params)
+        self.assertAlmostEqual(-2 * (loglike - my_mflike.logp_const), chi2s['tt-te-et-ee'], 2)

--- a/mflike/tests/test_mflike.py
+++ b/mflike/tests/test_mflike.py
@@ -462,3 +462,64 @@ class MFLikeTest(unittest.TestCase):
 
         loglike = my_mflike.loglike(cl_dict, fg_totals, **nuis_params)
         self.assertAlmostEqual(-2 * (loglike - my_mflike.logp_const), chi2s['tt-te-et-ee'], 2)
+
+    def test_calibration_correlation_priors(self):
+        nuis_params = common_nuis_params | TT_nuis_params | TE_nuis_params | EE_nuis_params
+        nuis_params = {k: v for k, v in nuis_params.items() if "calE" not in k}
+        nuis_params["cal_LAT_93"] = 0.95
+        nuis_params["cal_LAT_145"] = 1.0
+        nuis_params["cal_LAT_225"] = 1.05
+
+        info_cov = {
+            "likelihood": {
+                "mflike.TTTEEE": {
+                    "input_file": pre + "00000.fits",
+                    "cov_Bbl_file": "data_sacc_w_covar_and_Bbl.fits",
+                    "parameter_covariance": {
+                        "mean": 1,
+                        "cov": os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                            "example_cov.txt")
+                    }
+                },
+            },
+            "theory": {
+                "camb": {"extra_args": {"lens_potential_accuracy": 1}},
+                "mflike.BandpowerForeground": {"requested_cls": ["tt", "te", "ee"]},
+            },
+            "params": cosmo_params | nuis_params,
+            "packages_path": packages_path,
+        }
+
+        model = get_model(info_cov)
+        cov_mflike = model.likelihood["mflike.TTTEEE"]
+        chi2_cov = -2 * (model.logpost(nuis_params) - cov_mflike.logp_const)
+
+        nuis_info = common_nuis_params | TT_nuis_params | TE_nuis_params | EE_nuis_params
+        for param in ["cal_LAT_93", "cal_LAT_145", "cal_LAT_225"]:
+            nuis_info[param] = {
+                "prior": {
+                    "dist": "norm",
+                    "loc": 1.0,
+                    "scale": 1e-2
+                },
+            }
+        info_priors = {
+            "likelihood": {
+                "mflike.TTTEEE": {
+                    "input_file": pre + "00000.fits",
+                    "cov_Bbl_file": "data_sacc_w_covar_and_Bbl.fits",
+                },
+            },
+            "theory": {
+                "camb": {"extra_args": {"lens_potential_accuracy": 1}},
+                "mflike.BandpowerForeground": {"requested_cls": ["tt", "te", "ee"]},
+            },
+            "params": cosmo_params | nuis_info,
+            "packages_path": packages_path,
+        }
+
+        model = get_model(info_priors)
+        my_mflike = model.likelihood["mflike.TTTEEE"]
+        chi2_priors = -2 * (model.logpost(nuis_params) - my_mflike.logp_const)
+
+        self.assertAlmostEqual(chi2_cov - chi2_priors, 2. * cov_mflike.parameter_covariance["logp_const"], 2)


### PR DESCRIPTION
Add functionality for covariance between internal parameters.

Looking at the importance of covariance between calibration parameters for the LAT, this branch adds the ability to load in a Gaussian mean + covariance for internal parameters.

I've added an example for the LAT sims, it currently works by having the option

```
parameter_covariance:
  mean: calib_mean.txt
  cov: calib_cov.txt
```

in the yaml file.

The covariance file should have a structure like:

```
# A B C
1.0 0.0 0.0
0.0 1.0 0.0
0.0 0.0 1.0
```

where the first line specifies the parameters used, and the numbers after specify the full covariance matrix (in this example, this is an uncorrelated unit covariance).

The means can be provided as either a file in a similar format, as an array of numbers, or as a single number (which will be broadcast into an array of numbers).